### PR TITLE
Remove production readiness disclaimer from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Geth with additional RPC method `flashbots_validateBuilderSubmissionV1`.
 The new method accepts `github.com/flashbots/go-boost-utils/types.BuilderSubmitBlockRequest` - boost relay builders' block submission.  
 It will ensure that the block is valid and that it transfers the expected funds to the fee recipient.  
 
-This code is *not* production ready. Do not use in production environments.  
-
 ## Blacklisting
 
 By default the node will load blacklisted addresses from `ofac_blacklist.json` from working directory. You can specify the path to the file via `--builder.validation_blacklist`.  


### PR DESCRIPTION
It seems this block validation code is used by most MEV relays on mainnet, so I think the "do not use in production" label is a bit inaccurate. Perhaps it could be replaced with a different disclaimer?